### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ client_protos_headers = wayland_scanner_client.process(xml)
 lib_client_protos = static_library(
   'client_protos',
   [ client_protos_src, client_protos_headers ],
+  dependencies: [ wayland_client ],
 )
 
 client_protos = declare_dependency(


### PR DESCRIPTION
`wayland-scanner` adds dependency on `"wayland-util.h"` which is part of libwayland but may not be visible by default if built with `--prefix` that's neither `/usr` nor `/usr/local`. More noticible on BSDs as headers from packages are [not in the default search path](https://wiki.freebsd.org/WarnerLosh/UsrLocal) e.g.,
```c
$ meson setup _build
[...]
Found pkg-config: /usr/local/bin/pkg-config (1.8.0)
Run-time dependency wayland-protocols found: YES 1.24
Run-time dependency wayland-client found: YES 1.20.0
Program wayland-scanner found: YES (/usr/local/bin/wayland-scanner)
[...]

$ meson compile -C _build
FAILED: libclient_protos.a.p/meson-generated_idle-inhibit-unstable-v1-protocol.c.o
cc -Ilibclient_protos.a.p -I. -I../../a/sway-audio-idle-inhibit -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -MD -MQ libclient_protos.a.p/meson-generated_idle-inhibit-unstable-v1-protocol.c.o -MF libclient_protos.a.p/meson-generated_idle-inhibit-unstable-v1-protocol.c.o.d -o libclient_protos.a.p/meson-generated_idle-inhibit-unstable-v1-protocol.c.o -c libclient_protos.a.p/idle-inhibit-unstable-v1-protocol.c
libclient_protos.a.p/idle-inhibit-unstable-v1-protocol.c:28:10: fatal error: 'wayland-util.h' file not found
#include "wayland-util.h"
         ^~~~~~~~~~~~~~~~
1 error generated.
