### PR TITLE
Fixed build with musl libc

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <libgen.h>
 #include <cstring>
 
 #include "data.hpp"


### PR DESCRIPTION
While packaging for Void, I noticed that SwayAudioIdleInhibit doesn't build with musl libc. The issue is the usage of `basename(3)` whereof 2 different implementations exist on Linux:

* the POSIX version where you should `include <libgen.h>`
* the GNU version where you should `#define _GNU_SOURCE`

glibc will ignore this and default to the GNU version whereas musl is strict here and wants one of them explicitely set.

To keep things portable I opted for the POSIX version and tested that things still work as expected.