### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <libgen.h>
 #include <cstring>
 
 #include "data.hpp"


### PR DESCRIPTION
Regressed by 899843978ebd. Switching from Clang/libc++ to GCC/libstdc++ doesn't help. GNU libc also defines `basename` in `<string.h>` for OSF/1 compatibility. See also [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/basename.html).

Clang/libc++ 13.0.0:
```c++
src/main.cpp:7:17: error: use of undeclared identifier 'basename'
  string name = basename(argv[0]);
                ^
```

GCC/libstdc++ 11.2.0:
```c++
src/main.cpp: In function 'void showHelp(char**)':
src/main.cpp:7:17: error: 'basename' was not declared in this scope; did you mean 'rename'?
    7 |   string name = basename(argv[0]);
      |                 ^~~~~~~~
      |                 rename
```
