### PR TITLE
Reverted idle.cpp so it functions again.

### DIFF
--- a/src/idle.cpp
+++ b/src/idle.cpp
@@ -55,14 +55,14 @@ void Idle::update(bool isRunning) {
     if (idle == NULL) {
       idle = zwp_idle_inhibit_manager_v1_create_inhibitor(
           wl_idle_inhibit_manager, surface);
-      wl_display_sync(display);
+      wl_display_roundtrip(display);
     }
     cout << "IDLE INHIBITED" << endl;
   } else {
     if (idle != NULL) {
       zwp_idle_inhibitor_v1_destroy(idle);
       idle = NULL;
-      wl_display_sync(display);
+      wl_display_roundtrip(display);
     }
     cout << "NOT IDLE INHIBITED" << endl;
   }

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -29,7 +29,7 @@ int Pulse::init(SubscriptionType subscriptionType,
 void Pulse::sink_input_info_callback(pa_context *, const pa_sink_input_info *i,
                                      int, void *userdata) {
   Data *data = (Data *)userdata;
-  if (i && !i->corked) data->activeSink = true;
+if (i && !i->corked && i->client != 0) data->activeSink = true;
   pa_threaded_mainloop_signal(data->mainloop, 0);
 }
 

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -29,7 +29,7 @@ int Pulse::init(SubscriptionType subscriptionType,
 void Pulse::sink_input_info_callback(pa_context *, const pa_sink_input_info *i,
                                      int, void *userdata) {
   Data *data = (Data *)userdata;
-if (i && !i->corked && i->client != 0) data->activeSink = true;
+  if (i && !i->corked && i->client != PA_INVALID_INDEX) data->activeSink = true;
   pa_threaded_mainloop_signal(data->mainloop, 0);
 }
 
@@ -37,7 +37,7 @@ void Pulse::source_output_info_callback(pa_context *,
                                         const pa_source_output_info *i, int,
                                         void *userdata) {
   Data *data = (Data *)userdata;
-  if (i && !i->corked) data->activeSource = true;
+  if (i && !i->corked && i->client != PA_INVALID_INDEX) data->activeSource = true;
   pa_threaded_mainloop_signal(data->mainloop, 0);
 }
 


### PR DESCRIPTION
Prevent crash when audio device disconnects.

Should fix https://github.com/ErikReider/SwayAudioIdleInhibit/issues/10
and hopefully
https://github.com/ErikReider/SwayAudioIdleInhibit/issues/7

(not quite sure how to test that last one, but no more crashes when unplugging speaker usb cable on my  own laptop so...)