### PR TITLE
Safe handling of ignoredSourceOutputs array

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
   bool printSource = false;
   bool printSink = false;
 
-  char* ignoredSourceOutputs[MAX_IGNORED_SOURCE_OUTPUTS];
+  char* ignoredSourceOutputs[MAX_IGNORED_SOURCE_OUTPUTS] = {nullptr};
   int ignoredSourceOutputsCount = 0;
 
   if (argc > 1) {

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -44,12 +44,17 @@ void Pulse::source_output_info_callback(pa_context *,
   if (i && i->proplist) {
     const char *appName = pa_proplist_gets(i->proplist, "application.name");
     if (appName) {
-      int i = 0;
-      while (data->ignoredSourceOutputs[i] != nullptr) {
-        if (strcmp(appName, data->ignoredSourceOutputs[i]) == 0) {
+      int ignoredSourceOutputsCount = 0;
+      while (
+        data->ignoredSourceOutputs[ignoredSourceOutputsCount] != nullptr
+        && ignoreSourceOutput == false
+        && ignoredSourceOutputsCount < MAX_IGNORED_SOURCE_OUTPUTS
+      ) {
+        if (strcmp(appName, data->ignoredSourceOutputs[ignoredSourceOutputsCount]) == 0) {
           ignoreSourceOutput = true;
+          break;
         }
-        i++;
+        ignoredSourceOutputsCount++;
       }
     }
   }


### PR DESCRIPTION
GH issue: https://github.com/ErikReider/SwayAudioIdleInhibit/issues/7

I am adding safe(ish) memory handling for the `ignoredSourceOutputs` array. It fixes "segfault" caused by out-of-bound index access.

```
(gdb) p data->ignoredSourceOutputs[1]
$4 = 0x69682ac <error: Cannot access memory at address 0x69682ac>
```