### PR TITLE
Fix crash due to uninitialized ignored sources outputs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,14 +51,14 @@ int main(int argc, char *argv[]) {
           ignoredSourceOutputs[ignoredSourceOutputsCount++] = token;
           token = strtok_r(nullptr, " ", &saveptr);
         }
-
-        ignoredSourceOutputs[ignoredSourceOutputsCount] = nullptr;
       } else {
         showHelp(argv);
         return 0;
       }
     }
   }
+
+  ignoredSourceOutputs[ignoredSourceOutputsCount] = nullptr;
 
   pa_subscription_mask_t all_mask =
       (pa_subscription_mask_t)(PA_SUBSCRIPTION_MASK_SINK_INPUT |


### PR DESCRIPTION
If no source outputs to ignore were specified on the command line, the array was left completely uninitialized, resulting in a crash later on while iterating over it until the first null pointer.

Fix this by ensuring that there is always a null pointer at the end.

See #18.

----

Without this fix the program just crashed on startup here.