### PR TITLE
use media.name if no app name for ignoredSourceOutputs

### DIFF
--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -43,6 +43,7 @@ void Pulse::source_output_info_callback(pa_context *,
   bool ignoreSourceOutput = false;
   if (i && i->proplist) {
     const char *appName = pa_proplist_gets(i->proplist, "application.name");
+    if (!appName) appName = pa_proplist_gets(i->proplist, "media.name");
     if (appName) {
       int ignoredSourceOutputsCount = 0;
       while (


### PR DESCRIPTION
Allows for ignoring sources which do not have an application.name, instead using media.name to check as well. For example, this fixes having [cava](https://github.com/karlstav/cava) running causing it to be idle inhibited due to mic usage even if it is ignored due to it not having an application.name property.

I don't know any c++ at all, but this should work. Tested on 6.11.1 kernel with Arch and Hyprland, using Pipewire Pulse.