### PR TITLE
Move registry_listener from stack into static memory

### DIFF
--- a/src/idle.cpp
+++ b/src/idle.cpp
@@ -29,7 +29,7 @@ Idle::Idle() {
     exit(1);
   }
 
-  const struct wl_registry_listener registry_listener = {
+  const static struct wl_registry_listener registry_listener = {
       .global = global_add,
       .global_remove = global_remove,
   };


### PR DESCRIPTION
Fixes #25 

Explicitly move registry_listener into static memory.
Otherwise compiler might leave it on the stack, and when wayland server tries to call listener, it uses random garbage from stack as function address instead.