### PR TITLE
Use systemd/elogind Inhibit instead of the wayland protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SwayAudioIdleInhibit
 
-Prevents swayidle from sleeping while any application is outputting or
-receiving audio. Should work with all Wayland desktops that support the
-`zwp_idle_inhibit_manager_v1` protocol but only tested in Sway
+Prevents swayidle/hypridle from sleeping while any application is outputting or
+receiving audio. Requires systemd/elogind inhibit support.
 
 This only works for Pulseaudio / Pipewire Pulse
 
@@ -14,8 +13,13 @@ The package is available on the [AUR](https://aur.archlinux.org/packages/sway-au
 Other:
 
 ```zsh
-meson build
-ninja -C build
+# Can compile to use systemd or elogind
+# systemd (default)
+meson setup build -Dlogind-provider=systemd
+# or elogind for systemd-less systems
+meson setup build -Dlogind-provider=elogind
+
+meson compile -C build
 meson install -C build
 ```
 
@@ -60,7 +64,7 @@ or `modules-right` list.
 
 *Note: The FontAwesome font is used for the icons below*
 
-```
+```json
 	"custom/audio_idle_inhibitor": {
 		"format": "{icon}",
 		"exec": "sway-audio-idle-inhibit --dry-print-both-waybar",
@@ -74,4 +78,3 @@ or `modules-right` list.
 		}
 	},
 ```
-

--- a/include/idle.hpp
+++ b/include/idle.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
-#include "idle-inhibit-unstable-v1-client-protocol.h"
-
-using namespace std;
+#if HAVE_SYSTEMD
+#include <systemd/sd-bus.h>
+#include <systemd/sd-login.h>
+#elif HAVE_ELOGIND
+#include <elogind/sd-bus.h>
+#include <elogind/sd-login.h>
+#endif
 
 class Idle {
-	struct wl_compositor *compositor = NULL;
-	struct zwp_idle_inhibit_manager_v1 *wl_idle_inhibit_manager = NULL;
-	struct wl_surface *surface = NULL;
-	struct wl_display *display = NULL;
-	struct zwp_idle_inhibitor_v1 *idle = NULL;
+	struct sd_bus *bus = nullptr;
+	int fd = -1;
 
-	static void global_add(void *data, struct wl_registry *registry,
-						   uint32_t name, const char *interface, uint32_t);
-
-	static void global_remove(void *, struct wl_registry *, uint32_t);
+	void block();
+	void release_block();
 
   public:
 	Idle();

--- a/meson.build
+++ b/meson.build
@@ -1,58 +1,53 @@
 project(
-  'SwayAudioIdleInhibit',
-  'c', 'cpp',
-  version: '0.1.2',
-  default_options: [],
+	'SwayAudioIdleInhibit',
+	'cpp',
+	version: '0.1.2',
+	default_options: [
+		'c_std=c11',
+		'cpp_std=c++11',
+		'warning_level=2',
+		'werror=true',
+	],
 )
 
-wayland_protos = dependency('wayland-protocols')
-wayland_client = dependency('wayland-client', version: '>=1.14.91')
-
-wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
-
-wayland_scanner = find_program('wayland-scanner')
-wayland_scanner_code = generator(
-  wayland_scanner,
-  output: '@BASENAME@-protocol.c',
-  arguments: ['private-code', '@INPUT@', '@OUTPUT@'],
-)
-wayland_scanner_client = generator(
-  wayland_scanner,
-  output: '@BASENAME@-client-protocol.h',
-  arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
-)
-
-xml = join_paths([wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'])
-client_protos_src = wayland_scanner_code.process(xml)
-client_protos_headers = wayland_scanner_client.process(xml)
-
-lib_client_protos = static_library(
-  'client_protos',
-  [ client_protos_src, client_protos_headers ],
-  dependencies: [ wayland_client ],
+add_project_arguments(
+	[
+		'-Wno-unused-parameter',
+		'-Wno-unused-result',
+		'-Wno-missing-braces',
+		'-Wno-format-zero-length',
+		'-Wno-missing-field-initializers',
+		'-Wundef',
+		'-Wvla',
+		'-Wlogical-op',
+		'-Wmissing-include-dirs',
+		'-Wpointer-arith',
+		'-Winit-self',
+		'-Wimplicit-fallthrough=2',
+		'-Wendif-labels',
+		'-Wstrict-aliasing=2',
+		'-Woverflow',
+		'-Walloca',
+	],
+	language: 'cpp',
 )
 
-client_protos = declare_dependency(
-  link_with: lib_client_protos,
-  sources: client_protos_headers,
-)
+logind_dep = dependency('lib' + get_option('logind-provider'), required: true)
+
+add_project_arguments('-D', 'HAVE_' + get_option('logind-provider').to_upper(), language: 'cpp')
 
 executable(
-  'sway-audio-idle-inhibit',
-  [
-    './src/main.cpp',
-    './src/data.cpp',
-    './src/pulse.cpp',
-    './src/idle.cpp',
-  ],
-  include_directories: [
-    include_directories('include')
-  ],
-  dependencies: [
-    dependency('libpulse', version: '>= 15.0'),
-    wayland_protos,
-    wayland_client,
-    client_protos,
-  ],
-  install: true,
+	'sway-audio-idle-inhibit',
+	files(
+		'./src/data.cpp',
+		'./src/idle.cpp',
+		'./src/main.cpp',
+		'./src/pulse.cpp',
+	),
+	include_directories: include_directories('include'),
+	dependencies: [
+		dependency('libpulse', version: '>= 15.0'),
+		logind_dep,
+	],
+	install: true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('logind-provider', type: 'combo', choices: ['systemd', 'elogind'], value: 'systemd', description: 'Provider of logind support library')


### PR DESCRIPTION
This should fix: #32 and #16 🤞

I misread the `zwp_idle_inhibit_manager_v1` protocol spec and thought that a hidden surface could inhibit idle, which worked in Sway and Hyprland until they “fixed” the bug. There's no way (that I know of) to re-enable this functionality without making the `wl_surface` visible, so I decided to move to the systemd/elogind [Inhibit API](https://www.freedesktop.org/wiki/Software/systemd/inhibit/)