### PR TITLE
Prevent uncorked silent streams from inhibiting idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Ignore muted and zero-volume streams when deciding whether audio is running:
 sway-audio-idle-inhibit --ignore-muted-streams
 ```
 
+Ignore playback streams from specific applications by exact PulseAudio
+`application.name` values:
+
+```zsh
+sway-audio-idle-inhibit --ignore-sink-inputs "speech-dispatcher-dummy speech-dispatcher-espeak-ng"
+```
+
+Ignore recording streams from specific applications by exact PulseAudio
+`application.name` values:
+
+```zsh
+sway-audio-idle-inhibit --ignore-source-outputs "app-one app-two"
+```
+
 ## Waybar Integration
 
 A custom waybar module can be used to display an icon when any application is

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Monitor sinks: will print `RUNNING` or `NOT RUNNING`
 sway-audio-idle-inhibit --dry-print-sink
 ```
 
+Ignore muted and zero-volume streams when deciding whether audio is running:
+
+```zsh
+sway-audio-idle-inhibit --ignore-muted-streams
+```
+
 ## Waybar Integration
 
 A custom waybar module can be used to display an icon when any application is

--- a/include/data.hpp
+++ b/include/data.hpp
@@ -37,6 +37,7 @@ struct Data {
 	pa_subscription_mask_t pa_subscriptionType;
 
 	char **ignoredSourceOutputs;
+	bool ignoreMutedStreams;
 
 	Idle *idle = NULL;
 
@@ -45,7 +46,7 @@ struct Data {
 	Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 		 SubscriptionType subscriptionType,
 		 pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-		 char **ignoredSourceOutputs);
+		 char **ignoredSourceOutputs, bool ignoreMutedStreams);
 
 	void quit(int returnValue = 0);
 

--- a/include/data.hpp
+++ b/include/data.hpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-#define MAX_IGNORED_SOURCE_OUTPUTS 100
+#define MAX_IGNORED_APPS 100
 
 enum SubscriptionType {
 	SUBSCRIPTION_TYPE_IDLE,
@@ -36,6 +36,7 @@ struct Data {
 	SubscriptionType subscriptionType;
 	pa_subscription_mask_t pa_subscriptionType;
 
+	char **ignoredSinkInputs;
 	char **ignoredSourceOutputs;
 	bool ignoreMutedStreams;
 
@@ -46,7 +47,8 @@ struct Data {
 	Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 		 SubscriptionType subscriptionType,
 		 pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-		 char **ignoredSourceOutputs, bool ignoreMutedStreams);
+		 char **ignoredSinkInputs, char **ignoredSourceOutputs,
+		 bool ignoreMutedStreams);
 
 	void quit(int returnValue = 0);
 

--- a/include/pulse.hpp
+++ b/include/pulse.hpp
@@ -12,7 +12,7 @@ class Pulse {
   public:
 	int init(SubscriptionType subscriptionType,
 			 pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-			 char **ignoredSourceOutputs);
+			 char **ignoredSourceOutputs, bool ignoreMutedStreams);
 
   private:
 	static void sink_input_info_callback(pa_context *,
@@ -38,7 +38,8 @@ class Pulse {
 	void connect(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 				 SubscriptionType subscriptionType,
 				 pa_subscription_mask_t pa_subscriptionType,
-				 EventType eventType, char **ignoredSourceOutputs);
+				 EventType eventType, char **ignoredSourceOutputs,
+				 bool ignoreMutedStreams);
 
 	pa_threaded_mainloop *getMainLoop();
 

--- a/include/pulse.hpp
+++ b/include/pulse.hpp
@@ -12,7 +12,8 @@ class Pulse {
   public:
 	int init(SubscriptionType subscriptionType,
 			 pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-			 char **ignoredSourceOutputs, bool ignoreMutedStreams);
+			 char **ignoredSinkInputs, char **ignoredSourceOutputs,
+			 bool ignoreMutedStreams);
 
   private:
 	static void sink_input_info_callback(pa_context *,
@@ -38,8 +39,8 @@ class Pulse {
 	void connect(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 				 SubscriptionType subscriptionType,
 				 pa_subscription_mask_t pa_subscriptionType,
-				 EventType eventType, char **ignoredSourceOutputs,
-				 bool ignoreMutedStreams);
+				 EventType eventType, char **ignoredSinkInputs,
+				 char **ignoredSourceOutputs, bool ignoreMutedStreams);
 
 	pa_threaded_mainloop *getMainLoop();
 

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,10 @@ add_project_arguments('-D', 'HAVE_' + get_option('logind-provider').to_upper(), 
 if get_option('logind-provider') == 'systemd'
 	dep_systemd = dependency('systemd')
 	if dep_systemd.found()
-		systemd_service_install_dir = dep_systemd.get_variable(pkgconfig: 'systemduserunitdir')
+		systemd_service_install_dir = dep_systemd.get_variable(
+			pkgconfig: 'systemduserunitdir',
+			default_value: join_paths(get_option('libdir'), 'systemd', 'user'),
+		)
 	else
 		systemd_service_install_dir = join_paths(get_option('libdir'), 'systemd', 'user')
 	endif

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -6,12 +6,14 @@
 Data::Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 		   SubscriptionType subscriptionType,
 		   pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-		   char **ignoredSourceOutputs, bool ignoreMutedStreams) {
+		   char **ignoredSinkInputs, char **ignoredSourceOutputs,
+		   bool ignoreMutedStreams) {
 	this->mainloop = mainloop;
 	this->mainloop_api = mainloop_api;
 	this->subscriptionType = subscriptionType;
 	this->pa_subscriptionType = pa_subscriptionType;
 	this->eventCalled = eventType;
+	this->ignoredSinkInputs = ignoredSinkInputs;
 	this->ignoredSourceOutputs = ignoredSourceOutputs;
 	this->ignoreMutedStreams = ignoreMutedStreams;
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -6,13 +6,14 @@
 Data::Data(pa_threaded_mainloop *mainloop, pa_mainloop_api *mainloop_api,
 		   SubscriptionType subscriptionType,
 		   pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-		   char **ignoredSourceOutputs) {
+		   char **ignoredSourceOutputs, bool ignoreMutedStreams) {
 	this->mainloop = mainloop;
 	this->mainloop_api = mainloop_api;
 	this->subscriptionType = subscriptionType;
 	this->pa_subscriptionType = pa_subscriptionType;
 	this->eventCalled = eventType;
 	this->ignoredSourceOutputs = ignoredSourceOutputs;
+	this->ignoreMutedStreams = ignoreMutedStreams;
 
 	if (subscriptionType == SUBSCRIPTION_TYPE_IDLE)
 		idle = new Idle();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,8 @@ void showHelp(char **argv) {
 			"sink is running\n";
 	cout << "\t --dry-print-source \t\t Don't inhibit idle and print if any "
 			"source is running\n";
+	cout << "\t --ignore-muted-streams \t Don't inhibit idle for muted or "
+			"zero-volume streams\n";
 	cout << "\t --ignore-source-outputs \t\t Don't inhibit idle for these "
 			"source outputs\n";
 }
@@ -53,6 +55,7 @@ int main(int argc, char *argv[]) {
 	bool printBothWayBar = false;
 	bool printSource = false;
 	bool printSink = false;
+	bool ignoreMutedStreams = false;
 
 	char *ignoredSourceOutputs[MAX_IGNORED_SOURCE_OUTPUTS] = {nullptr};
 	int ignoredSourceOutputsCount = 0;
@@ -67,6 +70,8 @@ int main(int argc, char *argv[]) {
 				printBoth = true;
 			} else if (strcmp(argv[i], "--dry-print-both-waybar") == 0) {
 				printBothWayBar = true;
+			} else if (strcmp(argv[i], "--ignore-muted-streams") == 0) {
+				ignoreMutedStreams = true;
 			} else if (strcmp(argv[i], "--ignore-source-outputs") == 0 &&
 					   i + 1 < argc) {
 				char *saveptr;
@@ -94,21 +99,25 @@ int main(int argc, char *argv[]) {
 			return EXIT_FAILURE;
 		}
 		return Pulse().init(SUBSCRIPTION_TYPE_IDLE, all_mask, EVENT_TYPE_IDLE,
-							ignoredSourceOutputs);
+							ignoredSourceOutputs, ignoreMutedStreams);
 	} else if (printBoth) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH, all_mask,
-							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs);
+							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs,
+							ignoreMutedStreams);
 	} else if (printBothWayBar) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH_WAYBAR, all_mask,
-							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs);
+							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs,
+							ignoreMutedStreams);
 	} else if (printSink) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_SINK,
 							PA_SUBSCRIPTION_MASK_SINK_INPUT,
-							EVENT_TYPE_DRY_SINK, ignoredSourceOutputs);
+							EVENT_TYPE_DRY_SINK, ignoredSourceOutputs,
+							ignoreMutedStreams);
 	} else if (printSource) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_SOURCE,
 							PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT,
-							EVENT_TYPE_DRY_SOURCE, ignoredSourceOutputs);
+							EVENT_TYPE_DRY_SOURCE, ignoredSourceOutputs,
+							ignoreMutedStreams);
 	}
 	return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,21 @@ void showHelp(char **argv) {
 			"source is running\n";
 	cout << "\t --ignore-muted-streams \t Don't inhibit idle for muted or "
 			"zero-volume streams\n";
+	cout << "\t --ignore-sink-inputs \t\t Don't inhibit idle for these "
+			"sink inputs\n";
 	cout << "\t --ignore-source-outputs \t\t Don't inhibit idle for these "
 			"source outputs\n";
+}
+
+static void addIgnoredApps(char *arg, char **ignoredApps, int *ignoredAppsCount) {
+	char *saveptr;
+	char *token = strtok_r(arg, " ", &saveptr);
+	while (token != nullptr && *ignoredAppsCount < MAX_IGNORED_APPS) {
+		ignoredApps[(*ignoredAppsCount)++] = token;
+		token = strtok_r(nullptr, " ", &saveptr);
+	}
+
+	ignoredApps[*ignoredAppsCount] = nullptr;
 }
 
 static bool is_already_running() {
@@ -57,7 +70,9 @@ int main(int argc, char *argv[]) {
 	bool printSink = false;
 	bool ignoreMutedStreams = false;
 
-	char *ignoredSourceOutputs[MAX_IGNORED_SOURCE_OUTPUTS] = {nullptr};
+	char *ignoredSinkInputs[MAX_IGNORED_APPS + 1] = {nullptr};
+	char *ignoredSourceOutputs[MAX_IGNORED_APPS + 1] = {nullptr};
+	int ignoredSinkInputsCount = 0;
 	int ignoredSourceOutputsCount = 0;
 
 	if (argc > 1) {
@@ -72,17 +87,14 @@ int main(int argc, char *argv[]) {
 				printBothWayBar = true;
 			} else if (strcmp(argv[i], "--ignore-muted-streams") == 0) {
 				ignoreMutedStreams = true;
+			} else if (strcmp(argv[i], "--ignore-sink-inputs") == 0 &&
+					   i + 1 < argc) {
+				addIgnoredApps(argv[++i], ignoredSinkInputs,
+							   &ignoredSinkInputsCount);
 			} else if (strcmp(argv[i], "--ignore-source-outputs") == 0 &&
 					   i + 1 < argc) {
-				char *saveptr;
-				char *token = strtok_r(argv[++i], " ", &saveptr);
-				while (token != nullptr &&
-					   ignoredSourceOutputsCount < MAX_IGNORED_SOURCE_OUTPUTS) {
-					ignoredSourceOutputs[ignoredSourceOutputsCount++] = token;
-					token = strtok_r(nullptr, " ", &saveptr);
-				}
-
-				ignoredSourceOutputs[ignoredSourceOutputsCount] = nullptr;
+				addIgnoredApps(argv[++i], ignoredSourceOutputs,
+							   &ignoredSourceOutputsCount);
 			} else {
 				showHelp(argv);
 				return EXIT_SUCCESS;
@@ -99,25 +111,26 @@ int main(int argc, char *argv[]) {
 			return EXIT_FAILURE;
 		}
 		return Pulse().init(SUBSCRIPTION_TYPE_IDLE, all_mask, EVENT_TYPE_IDLE,
-							ignoredSourceOutputs, ignoreMutedStreams);
+							ignoredSinkInputs, ignoredSourceOutputs,
+							ignoreMutedStreams);
 	} else if (printBoth) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH, all_mask,
-							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs,
-							ignoreMutedStreams);
+							EVENT_TYPE_DRY_BOTH, ignoredSinkInputs,
+							ignoredSourceOutputs, ignoreMutedStreams);
 	} else if (printBothWayBar) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_BOTH_WAYBAR, all_mask,
-							EVENT_TYPE_DRY_BOTH, ignoredSourceOutputs,
-							ignoreMutedStreams);
+							EVENT_TYPE_DRY_BOTH, ignoredSinkInputs,
+							ignoredSourceOutputs, ignoreMutedStreams);
 	} else if (printSink) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_SINK,
 							PA_SUBSCRIPTION_MASK_SINK_INPUT,
-							EVENT_TYPE_DRY_SINK, ignoredSourceOutputs,
-							ignoreMutedStreams);
+							EVENT_TYPE_DRY_SINK, ignoredSinkInputs,
+							ignoredSourceOutputs, ignoreMutedStreams);
 	} else if (printSource) {
 		return Pulse().init(SUBSCRIPTION_TYPE_DRY_SOURCE,
 							PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT,
-							EVENT_TYPE_DRY_SOURCE, ignoredSourceOutputs,
-							ignoreMutedStreams);
+							EVENT_TYPE_DRY_SOURCE, ignoredSinkInputs,
+							ignoredSourceOutputs, ignoreMutedStreams);
 	}
 	return EXIT_SUCCESS;
 }

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -33,9 +33,29 @@ static bool isUncorkedClientStream(int corked, uint32_t client) {
 	return !corked && client != PA_INVALID_INDEX;
 }
 
+static bool isIgnoredApplication(pa_proplist *proplist, char **ignoredApps) {
+	if (!proplist)
+		return false;
+
+	const char *appName = pa_proplist_gets(proplist, "application.name");
+	if (!appName)
+		return false;
+
+	for (int appIndex = 0; appIndex < MAX_IGNORED_APPS; appIndex++) {
+		if (!ignoredApps[appIndex])
+			return false;
+
+		if (strcmp(appName, ignoredApps[appIndex]) == 0)
+			return true;
+	}
+
+	return false;
+}
+
 int Pulse::init(SubscriptionType subscriptionType,
 				pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-				char **ignoredSourceOutputs, bool ignoreMutedStreams) {
+				char **ignoredSinkInputs, char **ignoredSourceOutputs,
+				bool ignoreMutedStreams) {
 	pa_threaded_mainloop *mainloop = getMainLoop();
 	pa_mainloop_api *mainloop_api = getMainLoopApi(mainloop);
 	if (pa_threaded_mainloop_start(mainloop)) {
@@ -43,7 +63,8 @@ int Pulse::init(SubscriptionType subscriptionType,
 		return 1;
 	}
 	connect(mainloop, mainloop_api, subscriptionType, pa_subscriptionType,
-			eventType, ignoredSourceOutputs, ignoreMutedStreams);
+			eventType, ignoredSinkInputs, ignoredSourceOutputs,
+			ignoreMutedStreams);
 	return 0;
 }
 
@@ -51,7 +72,8 @@ void Pulse::sink_input_info_callback(pa_context *, const pa_sink_input_info *i,
 									 int, void *userdata) {
 	Data *data = (Data *)userdata;
 	if (i && isUncorkedClientStream(i->corked, i->client) &&
-		streamPassesVolumeFilter(data, i->mute, i->has_volume, &i->volume))
+		streamPassesVolumeFilter(data, i->mute, i->has_volume, &i->volume) &&
+		!isIgnoredApplication(i->proplist, data->ignoredSinkInputs))
 		data->activeSink = true;
 	pa_threaded_mainloop_signal(data->mainloop, 0);
 }
@@ -60,27 +82,9 @@ void Pulse::source_output_info_callback(pa_context *,
 										const pa_source_output_info *i, int,
 										void *userdata) {
 	Data *data = (Data *)userdata;
-	bool ignoreSourceOutput = false;
-	if (i && i->proplist) {
-		const char *appName = pa_proplist_gets(i->proplist, "application.name");
-		if (appName) {
-			int ignoredSourceOutputsCount = 0;
-			while (data->ignoredSourceOutputs[ignoredSourceOutputsCount] !=
-					   nullptr &&
-				   ignoreSourceOutput == false &&
-				   ignoredSourceOutputsCount < MAX_IGNORED_SOURCE_OUTPUTS) {
-				if (strcmp(appName, data->ignoredSourceOutputs
-										[ignoredSourceOutputsCount]) == 0) {
-					ignoreSourceOutput = true;
-					break;
-				}
-				ignoredSourceOutputsCount++;
-			}
-		}
-	}
 	if (i && isUncorkedClientStream(i->corked, i->client) &&
 		streamPassesVolumeFilter(data, i->mute, i->has_volume, &i->volume) &&
-		!ignoreSourceOutput)
+		!isIgnoredApplication(i->proplist, data->ignoredSourceOutputs))
 		data->activeSource = true;
 	pa_threaded_mainloop_signal(data->mainloop, 0);
 }
@@ -199,11 +203,11 @@ void Pulse::connect(pa_threaded_mainloop *mainloop,
 					pa_mainloop_api *mainloop_api,
 					SubscriptionType subscriptionType,
 					pa_subscription_mask_t pa_subscriptionType,
-					EventType eventType, char **ignoredSourceOutputs,
-					bool ignoreMutedStreams) {
+					EventType eventType, char **ignoredSinkInputs,
+					char **ignoredSourceOutputs, bool ignoreMutedStreams) {
 	Data *data = new Data(mainloop, mainloop_api, subscriptionType,
-						  pa_subscriptionType, eventType, ignoredSourceOutputs,
-						  ignoreMutedStreams);
+						  pa_subscriptionType, eventType, ignoredSinkInputs,
+						  ignoredSourceOutputs, ignoreMutedStreams);
 
 	pa_context *context = getContext(mainloop, mainloop_api, data);
 

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -12,9 +12,30 @@
 #include "data.hpp"
 #include "pulse.hpp"
 
+static bool hasNonZeroVolume(const pa_cvolume *volume) {
+	for (uint8_t channel = 0; channel < volume->channels; channel++) {
+		if (volume->values[channel] > PA_VOLUME_MUTED)
+			return true;
+	}
+
+	return false;
+}
+
+static bool streamPassesVolumeFilter(const Data *data, int mute, int hasVolume,
+									 const pa_cvolume *volume) {
+	if (!data->ignoreMutedStreams)
+		return true;
+
+	return !mute && (!hasVolume || hasNonZeroVolume(volume));
+}
+
+static bool isUncorkedClientStream(int corked, uint32_t client) {
+	return !corked && client != PA_INVALID_INDEX;
+}
+
 int Pulse::init(SubscriptionType subscriptionType,
 				pa_subscription_mask_t pa_subscriptionType, EventType eventType,
-				char **ignoredSourceOutputs) {
+				char **ignoredSourceOutputs, bool ignoreMutedStreams) {
 	pa_threaded_mainloop *mainloop = getMainLoop();
 	pa_mainloop_api *mainloop_api = getMainLoopApi(mainloop);
 	if (pa_threaded_mainloop_start(mainloop)) {
@@ -22,14 +43,15 @@ int Pulse::init(SubscriptionType subscriptionType,
 		return 1;
 	}
 	connect(mainloop, mainloop_api, subscriptionType, pa_subscriptionType,
-			eventType, ignoredSourceOutputs);
+			eventType, ignoredSourceOutputs, ignoreMutedStreams);
 	return 0;
 }
 
 void Pulse::sink_input_info_callback(pa_context *, const pa_sink_input_info *i,
 									 int, void *userdata) {
 	Data *data = (Data *)userdata;
-	if (i && !i->corked && i->client != PA_INVALID_INDEX)
+	if (i && isUncorkedClientStream(i->corked, i->client) &&
+		streamPassesVolumeFilter(data, i->mute, i->has_volume, &i->volume))
 		data->activeSink = true;
 	pa_threaded_mainloop_signal(data->mainloop, 0);
 }
@@ -56,7 +78,9 @@ void Pulse::source_output_info_callback(pa_context *,
 			}
 		}
 	}
-	if (i && !i->corked && i->client != PA_INVALID_INDEX && !ignoreSourceOutput)
+	if (i && isUncorkedClientStream(i->corked, i->client) &&
+		streamPassesVolumeFilter(data, i->mute, i->has_volume, &i->volume) &&
+		!ignoreSourceOutput)
 		data->activeSource = true;
 	pa_threaded_mainloop_signal(data->mainloop, 0);
 }
@@ -175,9 +199,11 @@ void Pulse::connect(pa_threaded_mainloop *mainloop,
 					pa_mainloop_api *mainloop_api,
 					SubscriptionType subscriptionType,
 					pa_subscription_mask_t pa_subscriptionType,
-					EventType eventType, char **ignoredSourceOutputs) {
+					EventType eventType, char **ignoredSourceOutputs,
+					bool ignoreMutedStreams) {
 	Data *data = new Data(mainloop, mainloop_api, subscriptionType,
-						  pa_subscriptionType, eventType, ignoredSourceOutputs);
+						  pa_subscriptionType, eventType, ignoredSourceOutputs,
+						  ignoreMutedStreams);
 
 	pa_context *context = getContext(mainloop, mainloop_api, data);
 


### PR DESCRIPTION
This pull request adds new features and refactors the code to allow users to ignore muted or zero-volume streams, as well as streams from specific applications, when determining if audio is running. It also simplifies and unifies the handling of ignored applications for both sink inputs and source outputs, and updates the documentation accordingly. This should help users prevent certain apps that maintain uncorked silent streams from inhibiting idle.

Fixes: #43 

**New filtering features:**

* Added `--ignore-muted-streams` option to ignore muted or zero-volume streams when deciding if audio is running. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R88-R97) [[2]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089R15-R76)
* Added `--ignore-sink-inputs` and `--ignore-source-outputs` options, allowing users to specify PulseAudio `application.name` values to be ignored for sinks and sources, respectively. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R88-R97) [[2]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089R15-R76) [[3]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089L41-R87) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R85)

**Codebase refactoring and simplification:**

* Unified the maximum number of ignored applications for both sink inputs and source outputs via `MAX_IGNORED_APPS`, replacing the previous `MAX_IGNORED_SOURCE_OUTPUTS`.
* Refactored the `Data` structure and related functions to accept and handle both ignored sink inputs and source outputs, as well as the muted streams option. [[1]](diffhunk://#diff-f912dfb6a851b814cbeec13a9615c811602118d5d7fca23aaee5d5cbe5bd38ffR39-R41) [[2]](diffhunk://#diff-f912dfb6a851b814cbeec13a9615c811602118d5d7fca23aaee5d5cbe5bd38ffL48-R51) [[3]](diffhunk://#diff-009fc4b513f11ceea77f7c4c20a542fa5e707cf8936ace1fd8fdff68ef328915L9-R18) [[4]](diffhunk://#diff-8f2a34a1de78c6b4b9c29fcf0211532b215032b98385757897c6239e3e5d2693L15-R16) [[5]](diffhunk://#diff-8f2a34a1de78c6b4b9c29fcf0211532b215032b98385757897c6239e3e5d2693L41-R43) [[6]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089L178-R210)
* Consolidated and simplified the logic for filtering ignored applications and muted/zero-volume streams into reusable static helper functions in `pulse.cpp`. [[1]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089R15-R76) [[2]](diffhunk://#diff-6a9dfd283554302f3a8a82daae60ce79b5bf2fbc38ca043309067782be412089L41-R87)

**Documentation updates:**

* Updated the `README.md` to document the new command-line options for ignoring muted streams and specific applications.

**Build system improvement:**

* Improved the fallback logic for determining the systemd user unit directory in `meson.build`.

** AI Disclosure **
This PR was almost entirely made with the use of AI. I've manually reviewed the changes on a best effort basis and am happy to take responsibility for the code.